### PR TITLE
Improve PWA and iOS behaviour

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
     <title>Kennzeichen-Raten</title>
     <link

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "js-levenshtein": "^1.1.6",
         "json5": "^2.2.3",
+        "modern-normalize": "^2.0.0",
         "ramda": "^0.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3624,6 +3625,17 @@
         "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
         "ufo": "^1.1.2"
+      }
+    },
+    "node_modules/modern-normalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-2.0.0.tgz",
+      "integrity": "sha512-CxBoEVKh5U4DH3XuNbc5ONLF6dQBc8dSc7pdZ1957FGbIO5JBqGqqchhET9dTexri8/pk9xBL6+5ceOtCIp1QA==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "js-levenshtein": "^1.1.6",
     "json5": "^2.2.3",
+    "modern-normalize": "^2.0.0",
     "ramda": "^0.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -1,6 +1,7 @@
 {
   "name": "Kennzeichen-Raten",
-  "short_name": "Kennzeichen-Raten",
+  "short_name": "KZ Raten",
+  "start_url": "/kennzeichen-raten/",
   "icons": [
     {
       "src": "/kennzeichen-raten/android-chrome-192x192.png",
@@ -14,6 +15,6 @@
     }
   ],
   "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "background_color": "#1a2328",
   "display": "standalone"
 }

--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -1,3 +1,5 @@
+@import '../../../node_modules/modern-normalize/modern-normalize.css';
+
 @font-face {
   font-family: 'fe-schrift';
   src:
@@ -13,13 +15,26 @@
 
 html,
 body {
+  position: fixed;
+  overflow: hidden;
   font-family: Arial, Helvetica, sans-serif;
   color: #fff;
   background-color: #1a2328;
 }
-body {
-  max-width: 100%;
-  overflow-x: hidden;
+
+#root {
+  width: 100vw;
+  height: 100vh;
+  position: relative;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+}
+
+@supports(width: 1dvh) {
+  #root {
+    width: 100dvw;
+    height: 100dvh;
+  }
 }
 
 .background,
@@ -70,9 +85,17 @@ body {
   position: relative;
   max-width: 380px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 2rem 1rem;
   z-index: 1;
 }
+
+@supports(padding: max(0px)) {
+  .main {
+    padding-left: max(1rem, env(safe-area-inset-left));
+    padding-right: max(1rem, env(safe-area-inset-right));
+  }
+}
+
 .main.hidden {
   display: none;
 }

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -5,12 +5,12 @@ import {
   Outlet,
 } from 'react-router-dom'
 
-import Header from '../Header'
 import { makeTranslationValue } from '../../hooks/translation'
 import { TranslationContext } from '../../context/translation'
 import translations from '../../data/translations.json'
 import { useKeySequenceDetector } from '../../hooks/dom'
 import './index.css'
+import Header from '../Header'
 
 export default function App() {
   const [language, setLanguage] = useState('de')

--- a/src/pages/Database/index.css
+++ b/src/pages/Database/index.css
@@ -10,6 +10,8 @@
   flex: 1;
   margin-left: 0.5em;
   padding: 0.25em;
+  border: 0;
+  border-radius: 0;
 }
 
 .database__table {


### PR DESCRIPTION
I’ve got several improvements in mind for this repository. This first PR is kept as small as possible. Where needed, I can provide screenshots about the improvements.

- Add modern-normalize for several cross-browser fixes
  - To prevent unintentional cascade issues, the import order of CSS is changed
  - Reduced regression of search input
- The viewport meta tag is adjusted
  - To comply with accessibility requirements https://dequeuniversity.com/rules/axe/4.4/meta-viewport
  - Improve rendering on iPhone X and above https://webkit.org/blog/7929/designing-websites-for-iphone-x/
- Improve scroll behaviour on iPhone
- Web app manifest changes are added, to comply with best practices and meet installability requirements:
  - Short name should be kept under 12 characters to minimize the possibility of truncation
  - Manifest start URL should be defined
  - Update `background_color` to conform with other instances of app background color